### PR TITLE
振り返りグラフを見やすくなるように改善

### DIFF
--- a/app/webapp/poll/templates/poll/speaker_res.html
+++ b/app/webapp/poll/templates/poll/speaker_res.html
@@ -8,7 +8,7 @@
 {% block content %}
     <h1>振り返りのページ</h1>
 
-    <a href="{% url 'poll:index' %}" class="btn btn-secondary btn-sm">TOPに戻る</a>
+    <a href="{% url 'poll:index' %}" class="btn btn-secondary btn-sm">HOMEに戻る</a>
 
     {# スライド数のグラフをバインドする要素の準備 #}
     {% for i in slide_list %}

--- a/app/webapp/poll/templates/poll/speaker_res.html
+++ b/app/webapp/poll/templates/poll/speaker_res.html
@@ -87,6 +87,16 @@
 
         {# 折れ線グラフ作成 #}
         for (let i = 0; i < {{ slide_num }}; i++) {
+            let array1 = data1[i].slice(1, data1[i].length - 1);
+            let array2 = data2[i].slice(1, data2[i].length - 1);
+            let array3 = data3[i].slice(1, data3[i].length - 1);
+            let max_array = [Math.max(...array1), Math.max(...array2), Math.max(...array3)];
+            let max_val = Math.max(...max_array);
+            let y_tick_val = [];
+            for(let i=0; i<max_val+1; i++) {
+                y_tick_val.push(i);
+            }
+
             c3.generate({
                 bindto: "#slide_" + (i + 1),
                 padding: {
@@ -115,13 +125,9 @@
                         }
                     },
                     y: {
-                        min: 0,
-                        tick: {
-                            format: d3.format('d')
-                        },
-                        padding: {bottom: 0}
+                        tick: {values: y_tick_val}
                     }
-                },
+                 },
                 grid: {
                     x: {
                         show: false

--- a/app/webapp/poll/templates/poll/speaker_res.html
+++ b/app/webapp/poll/templates/poll/speaker_res.html
@@ -113,6 +113,13 @@
                         tick: {
                             format: '%H:%M:%S'
                         }
+                    },
+                    y: {
+                        min: 0,
+                        tick: {
+                            format: d3.format('d')
+                        },
+                        padding: {bottom: 0}
                     }
                 },
                 grid: {

--- a/app/webapp/poll/templates/poll/speaker_res.html
+++ b/app/webapp/poll/templates/poll/speaker_res.html
@@ -115,7 +115,14 @@
                         }
                     }
                 },
-
+                grid: {
+                    x: {
+                        show: false
+                    },
+                    y: {
+                        show: true
+                    }
+                }
             });
         }
     </script>

--- a/app/webapp/poll/templates/poll/speaker_res.html
+++ b/app/webapp/poll/templates/poll/speaker_res.html
@@ -19,20 +19,20 @@
     {# コメント一覧表 #}
     <table class="table table-striped table-bordered">
         <thead>
-            <tr>
-                <th scope="col">スライド</th>
-                <th scope="col">時刻</th>
-                <th scope="col">内容</th>
-            </tr>
+        <tr>
+            <th scope="col">スライド</th>
+            <th scope="col">時刻</th>
+            <th scope="col">内容</th>
+        </tr>
         </thead>
         <tbody>
-            {% for comment in comment_dic_list %}
-                    <tr>
-                        <td>{{ comment.slide }}</td>
-                        <td>{{ comment.time }}</td>
-                        <td>{{ comment.text }}</td>
-                    </tr>
-            {% endfor %}
+        {% for comment in comment_dic_list %}
+            <tr>
+                <td>{{ comment.slide }}</td>
+                <td>{{ comment.time }}</td>
+                <td>{{ comment.text }}</td>
+            </tr>
+        {% endfor %}
         </tbody>
     </table>
 
@@ -88,7 +88,7 @@
         {# 折れ線グラフ作成 #}
         for (let i = 0; i < {{ slide_num }}; i++) {
             c3.generate({
-                bindto: "#slide_" + (i+1),
+                bindto: "#slide_" + (i + 1),
                 padding: {
                     right: 20
                 },
@@ -100,7 +100,12 @@
                         data1[i],
                         data2[i],
                         data3[i]
-                    ]
+                    ],
+                    types: {
+                        分かった: 'area',
+                        もう知ってる: 'area',
+                        分からない: 'area'
+                    }
                 },
                 axis: {
                     x: {
@@ -110,6 +115,7 @@
                         }
                     }
                 },
+
             });
         }
     </script>


### PR DESCRIPTION
- プロットするデータとデータの時間差を最低10秒は確保するようにしました．
 例えば，12:00:00, 12:00:05, 12:00:10にそれぞれ「分かった」が1票入ったとすると，0秒のときに+1票，10秒のときに+2票されます．（←この仕様は無くなりました）
- グラフの目盛りの時間が被って読めなくなるのを完全に防ぐのは現状不可能ですが，多少は改善できると思います．